### PR TITLE
Change working dir to /role in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.16 as builder
 ENV PYROOT=/venv
 ENV PYTHONUSERBASE=$PYROOT
-WORKDIR /
+# WORKDIR /
 RUN <<EOF
   apk update
   apk add --no-cache bc cargo gcc libffi-dev musl-dev openssl-dev rust python3-dev py3-pip
@@ -29,6 +29,7 @@ RUN <<EOF
     apk del build-deps
 EOF
 
+WORKDIR /role
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--version"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To build the documentation roles, you can run these commands :
 * with package installed with pip
   `ansible-gendoc render`.
 * with docker images
-  `docker run --user $(id -u):$(id -g) -v <path_role>:/role -it ansible-gendoc:latest render role`.
+  `docker run --user $(id -u):$(id -g) -v <path_role>:/role -it ansible-gendoc:latest render`.
 
 #### Use your personal template
 
@@ -68,8 +68,12 @@ To use a personal template, you need to `init` the template in the templates
 folder of your role. If `ansible-gendoc` find an existing file
 `templates/README.j2`, it will use it to render the README.md file.
 
+* with package installed with pip
+  `ansible-gendoc init`.
+* with docker images
+  `docker run --user $(id -u):$(id -g) -v <path_role>:/role -it ansible-gendoc:latest init`.
+
 ```bash
-ansible-gendoc init
 ls templates
 README.j2
 ```


### PR DESCRIPTION
Changing working dir to /role make pip usage and docker usage consistent.
Added command line for docker init.
