### PR TITLE
Enable ansible-gendoc for Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,22 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: Ubuntu
-            image: ubuntu-latest
+            image: ubuntu-20.04
+          - os: Ubuntu
+            image: ubuntu-22.04
+          - os: Ubuntu
+            image: ubuntu-24.04
           - os: macOS
-            image: macos-11
+            image: macos-12
+          - os: macOS
+            image: macos-13
+          - os: macOS
+            image: macos-14
+          - os: macOS
+            image: macos-15
       fail-fast: false
     defaults:
       run:

--- a/ansible_gendoc/__init__.py
+++ b/ansible_gendoc/__init__.py
@@ -1,3 +1,3 @@
 from importlib_metadata import version
 
-__version__ = version('ansible-gendoc')
+__version__ = version("ansible-gendoc")

--- a/ansible_gendoc/helpers.py
+++ b/ansible_gendoc/helpers.py
@@ -1,9 +1,10 @@
-from pathlib import Path
-from rich import print
-import re
-import os
 import fnmatch
+import os
+import re
+from pathlib import Path
+
 import yaml
+from rich import print
 
 
 def load_yml_file(fpath, verbose):
@@ -111,6 +112,7 @@ def controlleveltitle(mdfiles):
             file["content"] = re.sub(r"((?:[#]+))", r"#\1", file["content"])
     return mdfiles
 
+
 def _convert_dict_of_string(d):
 
     if isinstance(d, dict):
@@ -131,8 +133,8 @@ def convert_dict_of_string(dict):
     output = []
     for file in dict:
         temp = {}
-        temp["filename"] = file['filename']
-        temp['content'] = _convert_dict_of_string(file['content'])
+        temp["filename"] = file["filename"]
+        temp["content"] = _convert_dict_of_string(file["content"])
         output.append(temp)
 
     return output
@@ -143,15 +145,16 @@ def convert_string(dict):
     output = []
     for file in dict:
         temp = {}
-        temp["filename"] = file['filename']
-        value =  yaml.dump(file['content'],Dumper=MyDumper)
-        temp['content'] = re.sub(r'^(.)$',r'        \1', value)
+        temp["filename"] = file["filename"]
+        value = yaml.dump(file["content"], Dumper=MyDumper)
+        temp["content"] = re.sub(r"^(.)$", r"        \1", value)
         output.append(temp)
 
     return output
 
 
 import yaml
+
 
 class MyDumper(yaml.Dumper):
 

--- a/ansible_gendoc/main.py
+++ b/ansible_gendoc/main.py
@@ -1,23 +1,23 @@
+import os
+import shutil
+import sys
 from pathlib import Path
-from re import template
+from typing import Optional
+
+import typer
+
 from ansible_gendoc import __version__
 from ansible_gendoc.gendoc import Gendoc
-from typing import Optional
-import typer
-import os
-import sys
-import shutil
-
 
 app = typer.Typer()
 
 
 def _version_callback(value: bool) -> None:
     if value:
-        versionText = typer.style(
+        version_text = typer.style(
             f"ansible-gendoc v{__version__}", fg=typer.colors.RED, bg=typer.colors.WHITE
         )
-        typer.echo(versionText)
+        typer.echo(version_text)
         raise typer.Exit()
 
 
@@ -27,7 +27,10 @@ def init(
         default="./", help="The path of your role.", exists=True
     ),
     force: Optional[bool] = typer.Option(
-        False, "--force", "-f", help="Replace existing Template README.j2 in templates folder."
+        False,
+        "--force",
+        "-f",
+        help="Replace existing Template README.j2 in templates folder.",
     ),
 ):
     """
@@ -41,14 +44,13 @@ def init(
     if not os.path.isfile(os.path.join(path, "templates")):
         Path(os.path.dirname(template_path)).mkdir(parents=True, exist_ok=True)
     if not os.path.isfile(os.path.join(template_path, "README.j2")) or force:
-        pkgdir = sys.modules['ansible_gendoc'].__path__[0]
+        pkgdir = sys.modules["ansible_gendoc"].__path__[0]
         fullpath = os.path.join(pkgdir, "templates/README.j2")
         shutil.copy(fullpath, template_path)
     else:
         print("The template already exist !!!!")
         print("use --force to replace the existent.")
         raise typer.Exit(code=1)
-
 
 
 @app.command()
@@ -76,6 +78,7 @@ def render(
     )
     gendoc.render()
 
+
 @app.callback()
 def main(
     version: Optional[bool] = typer.Option(
@@ -88,6 +91,7 @@ def main(
     ),
 ) -> None:
     return
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
In Python 3.13, the function `template` has been removed from `re` package.
It does not use it, so it harmless to remove it.

I have used `black`and `isort` for the formatting, but it does not change everything else.

@stephrobert In the hope, you still want to maintain this project ;)
